### PR TITLE
Nginx Repo FIX

### DIFF
--- a/site-cookbooks/LAMP/files/default/lamp/roles/nginx/templates/RedHat.repo.j2
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/nginx/templates/RedHat.repo.j2
@@ -1,7 +1,7 @@
 [nginx]
 name=nginx repo
 {% if ansible_distribution|lower == 'redhat' %}
-baseurl=http://nginx.org/packages/{{ ansible_distribution|lower }}/{{ ansible_distribution_major_version }}/x86_64/
+baseurl=http://nginx.org/packages/rhel/{{ ansible_distribution_major_version }}/x86_64/
 {% else %}
 baseurl=http://nginx.org/packages/{{ ansible_distribution|lower }}/{{ ansible_distribution_major_version }}/x86_64/
 {% endif %}


### PR DESCRIPTION
The baseurl for Nginx Packages for RedHat changed from [ http://nginx.org/packages/redhat/ ] to [ http://nginx.org/packages/rhel/ ]. This fix will allow the LEMP playbook to successfully complete for RHEL 6 and RHEL 7 servers.